### PR TITLE
Fix a few small things

### DIFF
--- a/rootstock-touch-install
+++ b/rootstock-touch-install
@@ -103,12 +103,12 @@ trap cleanup 0 1 2 3 9 15
 
 usage()
 {
-	echo "usage: $(basename $0) <path to rootfs tarball> <path to android system.img> [options]\n
+	echo "usage: $(basename $0) <path to rootfs tarball> <path to android system.img> [options]
 	options:
 	-h|--help		this message
 	-c|--custom		path to customization tarball (needs to be tar.xz)
 	-k|--keep-userdata	do not wipe user data on device
-	-w|--wipe-file		absolute path of a file inside the image to wipe (empty)\n"
+	-w|--wipe-file		absolute path of a file inside the image to wipe (empty)"
 	exit 1
 }
 
@@ -131,6 +131,11 @@ while [ $# -gt 0 ]; do
 	esac
 	shift
 done
+
+if [ -z "$TARPATH" ]; then
+    echo "need valid rootfs tarball path"
+    usage
+fi
 
 TARBALL=$(basename $TARPATH)
 


### PR DESCRIPTION
newlines get printed, so remove them

fix weird messages when no argument is given:
```
basename: missing operand
Try 'basename --help' for more information.
error: no devices/emulators found
```