### PR TITLE
Add ability to use a custom Busybox/Toybox for possibly buggy extract

### DIFF
--- a/rootstock-touch-install
+++ b/rootstock-touch-install
@@ -51,6 +51,11 @@ convert_android_img()
 	fi
 }
 
+send_busybox() {
+	adb push "$BUSYBOX_PUSH" "/data/"
+	BUSYBOX="/data/`basename $BUSYBOX_PUSH`"
+}
+
 check_mounts(){
 	MOUNTS=$(do_shell "cat /proc/mounts")
 	if ! echo $MOUNTS | grep -qs '/cache'; then
@@ -108,11 +113,18 @@ usage()
 	-h|--help		this message
 	-c|--custom		path to customization tarball (needs to be tar.xz)
 	-k|--keep-userdata	do not wipe user data on device
-	-w|--wipe-file		absolute path of a file inside the image to wipe (empty)"
+	-w|--wipe-file		absolute path of a file inside the image to wipe (empty)
+	-b|--busybox		path to custom busybox (or toybox) to push/use on device"
 	exit 1
 }
 
 SUDOARGS="$@"
+
+# Holds the path to the busybox binary on the phone we will run commands with. The default one is in the recovery user's PATH, so we'll just leave it as is.
+BUSYBOX="busybox"
+
+# The busybox that we're going to push to the device
+BUSYBOX_PUSH=""
 
 while [ $# -gt 0 ]; do
 	case "$1" in
@@ -127,6 +139,9 @@ while [ $# -gt 0 ]; do
 			;;
 		-w|--wipe-file)
 			[ -n "$2" ] && WIPE_PATH=$2 shift || usage
+			;;
+		-b|--busybox)
+			[ -n "$2" ] && BUSYBOX_PUSH=$2 shift || usage
 			;;
 	esac
 	shift
@@ -180,6 +195,11 @@ check_mounts
 WORKDIR=$(mktemp -d /tmp/rootstock-touch-install.XXXXX)
 TMPMOUNT="$WORKDIR/tmpmount"
 
+if [ ! -z "$BUSYBOX_PUSH" ]; then
+	echo -n "Pushing Busybox to device ... "
+	send_busybox
+fi
+
 echo -n "transfering rootfs tarball ... "
 adb push $TARPATH /recovery/ >/dev/null 2>&1
 echo "[done]"
@@ -196,7 +216,7 @@ prepare_ubuntu_system
 echo "[done]"
 
 echo -n "unpacking rootfs tarball to system-image ... "
-do_shell "cd /cache/system && zcat /recovery/$TARBALL | tar xf -"
+do_shell "cd /cache/system && $BUSYBOX tar xf /recovery/$TARBALL"
 do_shell "mkdir -p /cache/system/android/firmware"
 do_shell "mkdir -p /cache/system/android/persist"
 do_shell "mkdir -p /cache/system/userdata"
@@ -216,7 +236,7 @@ echo "[done]"
 if [ ! -z "$CUST_TARPATH" ];then
 	echo -n "unpacking custom tarball"
 	do_shell "mkdir -p /cache/system/custom"
-	do_shell "cd /cache && xzcat /recovery/$CUST_TARBALL | tar xf -"
+	do_shell "cd /cache && $BUSYBOX xzcat /recovery/$CUST_TARBALL | $BUSYBOX tar xf -"
 	echo "[done]"
 fi
 

--- a/rootstock-touch-install
+++ b/rootstock-touch-install
@@ -90,6 +90,7 @@ prepare_ubuntu_system()
 
 cleanup()
 {
+	echo "Cleaning up... "
 	mount | grep -q $TMPMOUNT 2>/dev/null && umount $TMPMOUNT
 	cleanup_device
 	rm -rf $WORKDIR
@@ -101,6 +102,9 @@ cleanup_device()
 	[ -e $WORKDIR/device-clean ] && return
 	do_shell "umount /cache/system/ 2>/dev/null && rm -rf /cache/system 2>/dev/null"
 	do_shell "rm -f /recovery/$TARBALL"
+	if [ ! -z "$BUSYBOX_PUSH" ]; then
+		do_shell "rm $BUSYBOX 2>/dev/null"
+	fi
 	[ -e $WORKDIR ] && touch $WORKDIR/device-clean 2>/dev/null || true
 }
 
@@ -198,6 +202,7 @@ TMPMOUNT="$WORKDIR/tmpmount"
 if [ ! -z "$BUSYBOX_PUSH" ]; then
 	echo -n "Pushing Busybox to device ... "
 	send_busybox
+	echo "[done]"
 fi
 
 echo -n "transfering rootfs tarball ... "


### PR DESCRIPTION
I ran into issues with the steps that extract the rootfs tarball on the device. Specifically, either zcat or tar would run the device out of memory. I was able to remedy this by sending the `toybox` binary that was built with my Halium tree to the device and calling tar from that. This PR will add that functionality for all to enjoy, simply by using the `-b` switch.

Oh, also, I switched out `zcat $TARPATH | tar xf -` with `tar xf $TARPATH`. Please test this to ensure it doesn't break any of your devices.