### PR TITLE
Remove pin for stable-phone-overlay

### DIFF
--- a/rootstock-touch
+++ b/rootstock-touch
@@ -202,11 +202,11 @@ case $PROJECT_ in
 		PROJECT=$PROJECT_
 		;;
 	ubuntu-touch)
-		EXTRA_PPAS="ci-train-ppa-service/stable-phone-overlay:1001"
+		EXTRA_PPAS="ci-train-ppa-service/stable-phone-overlay"
 		PROJECT=$PROJECT_
 		;;
 	ubports-touch)
-		EXTRA_PPAS="ci-train-ppa-service/stable-phone-overlay:1001"
+		EXTRA_PPAS="ci-train-ppa-service/stable-phone-overlay"
 		PROJECT="ubuntu-touch"
 		;;
 esac


### PR DESCRIPTION
This removes the pin for stable-phone-overlay, even though we are still
not there yet to be able to completely remove it, this will allow us to
use newer packages from the official repo